### PR TITLE
Remove dark mode class

### DIFF
--- a/layouts/partials/header/header.html
+++ b/layouts/partials/header/header.html
@@ -1,4 +1,4 @@
-<header class="flex bg-white dark:bg-black items-center justify-between py-6">
+<header class="flex bg-white items-center justify-between py-6">
   <div class="hidden md:block">
     <a class="flex items-center hover:opacity-70 transition duration-300 ease-in-out" href="{{ site.BaseURL }}">
       {{ if site.Params.logo.showLogoImageOnDesktop }}


### PR DESCRIPTION
This PR just removes the `dark:bg-black` class from the `header` partial. 

With the class, users that use dark mode as their OS preference could see the header with a black background, which makes it hard to see the title or hamburger menu.

## Screenshots
### With `dark:bg-black` class
<img width="1721" alt="Screen Shot 2022-04-08 at 6 18 45 PM" src="https://user-images.githubusercontent.com/41454557/162541465-58b9b43b-8d0c-4962-b64a-28d6f827187f.png">

### Without `dark:bg-black` class
<img width="1721" alt="Screen Shot 2022-04-08 at 6 19 05 PM" src="https://user-images.githubusercontent.com/41454557/162541541-199afbaf-d14a-44a2-a262-bd53d07f912d.png">

